### PR TITLE
Prevent audio player from hanging or crashing

### DIFF
--- a/better_audio/better_audio.py
+++ b/better_audio/better_audio.py
@@ -126,9 +126,9 @@ class BetterAudio:
                             self.save_db()
 
                             url = next_song["url"]
-                            player = self.players[sid] = await self.voice_clients[sid].create_ytdl_player(url)
-                            player.volume = self.db[sid]["volume"]
-                            player.start()
+                            self.players[sid] = await self.voice_clients[sid].create_ytdl_player(url)
+                            self.players[sid].volume = self.db[sid]["volume"]
+                            self.players[sid].start()
                             self.playing[sid]["title"] = next_song["title"]
                             self.playing[sid]["author"] = next_song["author"]
                             self.playing[sid]["url"] = next_song["url"]
@@ -138,14 +138,14 @@ class BetterAudio:
                             pass
                     else:
                         if player.volume != self.db[sid]["volume"]:  # set volume while player is playing
-                            player.volume = float(self.db[sid]["volume"])
+                            self.players[sid].volume = float(self.db[sid]["volume"])
 
                         members = self.get_eligible_members(voice_client.channel.voice_members)
                         if len(members) > 0 and not self.players[sid].is_live:
-                            player[sid].resume()
+                            self.players[sid].resume()
                             self.playing[sid]["paused"] = False
                         if len(members) == 0 and not self.players[sid].is_live:
-                            player[sid].pause()
+                            self.players[sid].pause()
                             self.playing[sid]["paused"] = True
                         try:
                             possible_voters = len(self.get_eligible_members(voice_client.channel.voice_members))


### PR DESCRIPTION
This PR aims to fix the following issues:
* Python crashes when reloading the file while playing a song and having something else in queue. This is due to the Queue processing loop not recognizing it's playing already, and as such tries to fulfill the loop again, conflicting with the existing player.

* The player doesn't continue playing the queue after doing forceskip, stop, or disconnect. A temporary measure was to reload the file in order for it to continue.

* The player didn't recognize it was already disconnected after using disconnect. Using summon caused it to show the "I'm already in your channel" error message.